### PR TITLE
Check the length of the screencap before indexing into it

### DIFF
--- a/ppadb/command/transport/__init__.py
+++ b/ppadb/command/transport/__init__.py
@@ -45,7 +45,7 @@ class Transport(Command):
             conn.send(cmd)
             result = conn.read_all()
 
-        if result[5] == 0x0d:
+        if result and len(result) > 5 and result[5] == 0x0d:
             return result.replace(b'\r\n', b'\n')
         else:
             return result


### PR DESCRIPTION
Source: https://community.home-assistant.io/t/native-support-for-android-tv-android-devices/82792/463

Abridged traceback:

```
File "/usr/local/lib/python3.8/site-packages/androidtv/adb_manager/adb_manager_async.py", line 39, in screencap
  return await asyncio.get_running_loop().run_in_executor(None, self._device.screencap)
File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
  result = self.fn(*self.args, **self.kwargs)
File "/usr/local/lib/python3.8/site-packages/ppadb/command/transport/__init__.py", line 48, in screencap
  if result[5] == 0x0d:
IndexError: bytearray index out of range
```