### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Installation
 
 .. code-block:: console
 
-    $pip install -U pure-python-adb
+    $pip3 install -U pure-python-adb
 
 Examples
 ========


### PR DESCRIPTION
In line 40. It needs to be:
` $pip3 install -U pure-python-adb
`
Cause when you just type in pip install.... it will add the module to python2-site packages