### PR TITLE
FIX missing return in ppadb.command.transport: Transport.shell() for custom handler

### DIFF
--- a/ppadb/command/transport/__init__.py
+++ b/ppadb/command/transport/__init__.py
@@ -23,7 +23,7 @@ class Transport(Command):
         conn.send(cmd)
 
         if handler:
-            handler(conn)
+            return handler(conn)
         else:
             result = conn.read_all()
             conn.close()


### PR DESCRIPTION
ppadb.command.transport: Transport.shell() misses return, when a custom handler is supplied it's never used because of a missing return making the feature useless.