### PR TITLE
call disable-user  if app is device-admin 

### DIFF
--- a/ppadb/device.py
+++ b/ppadb/device.py
@@ -135,6 +135,10 @@ class Device(Transport, Serial, Input, Utils, WM, Traffic, CPUStat, BatteryStats
             return True
         elif m:
             logger.error(m.group(1))
+            if "DELETE_FAILED_DEVICE_POLICY_MANAGER" in m.group(1):
+                logger.info('App is device-admin, calling disable-user')
+                self.shell('pm disable-user {}'.format(package))
+                return self.uninstall(package)
             return False
         else:
             logger.error("There is no message after uninstalling")


### PR DESCRIPTION
Since lots of malware gets DEVICE_ADMIN permission adb uninstall command fails with DELETE_FAILED_DEVICE_POLICY_MANAGER error . Therefore if app is device-admin, call disable-user if uninstall fails.