### PR TITLE
Fixed "list-forward" exceptions on incorrect server output

### DIFF
--- a/ppadb/command/host/__init__.py
+++ b/ppadb/command/host/__init__.py
@@ -70,7 +70,7 @@ class Host(Command):
         device_forward_map = {}
         for line in result.split('\n'):
             if line:
-                serial, local, remote = line.split()
+                serial, local, remote = line.rsplit(' ', 2)
                 if serial not in device_forward_map:
                     device_forward_map[serial] = {}
 


### PR DESCRIPTION
Sometimes (mostly, after a devices goes offline and returns back) adb server goes crazy and starts responding " \f proto:port proto:port" to "host:list-forward" instead of specified "<serial> proto:port proto:port"